### PR TITLE
fixing broken links to SQL lesson in README.MD added perquisite formatting to Setup.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Library Carpentry
 
-The Library Carpentry module [SQL for Librarians](https://data-lessons.github.io/library-sql/) is maintained by [Elaine Wong](https://github.com/elainewong) and [Janice Chan](https://github.com/icecjan).
+The Library Carpentry module [SQL for Librarians](https://librarycarpentry.github.io/lc-sql/) is maintained by [Elaine Wong](https://github.com/elainewong) and [Janice Chan](https://github.com/icecjan).
 
 ## Background
 
@@ -61,3 +61,4 @@ you must install the software described below.
 
 [template]: {{ site.workshop_repo }}
 
+Library Carpentry. SQL for Librarians. June 2016. https://librarycarpentry.github.io/lc-sql/.

--- a/setup.md
+++ b/setup.md
@@ -16,7 +16,7 @@ Note: on Windows, the PortableApp download is recommended as the regular version
 ### SQLite
 
 
-This step is optional. If you are completing the tutorial with DB Browser for SQLite, you won't need to install SQLite separately. If you would like to run SQLite commands directly on the command line, you may need to install [SQLite](https://www.sqlite.org/) separately. 
+This step is optional. If you are completing the tutorial with DB Browser for SQLite, you won't need to install SQLite separately. If you would like to run SQLite commands directly on the command line, you may need to install [SQLite](https://www.sqlite.org/) separately.
 
 #### Linux and Mac OS x
 


### PR DESCRIPTION
Updated Links referring to "SQL for Librarians" lesson.  
1. first sentence under Title
2. citation link at the end of readme.  