### PR TITLE
Streamline database/data import setup, add SqliteOnline

### DIFF
--- a/setup.md
+++ b/setup.md
@@ -6,15 +6,46 @@ root: .
 
 ## Software Requirements
 
-
-### DB Browser for SQLite
+## DB Browser for SQLite
 
 You  will need to install [DB Browser for SQLite](http://sqlitebrowser.org) to complete these lessons. DB Browser for SQLite provides a graphical user interface for connecting to and interacting with a SQLite database. This application bundles SQLite, so you won't need to install SQLite separately.
 
 Note: on Windows, the PortableApp download is recommended as the regular version may take a long time to install on certain systems.
 
-### SQLite
+### Download the data
 
+To import data, you'll need to open DB Browser for SQLite and download a zip file containing the data files for this tutorial.
+
+1. Download the data files doaj-article-sample.zip from 
+[Zenodo](https://github.com/LibraryCarpentry/lc-sql/tree/gh-pages/files).
+2. Open the zip file with the zip utlity on your machine and save the folder and files to a location where you can easily find them. For example, your Desktop.
+2. Contained in the zip file are two files, doaj-article-sample.db and doaj-article-sample.db.sql. You can either open the database file (less steps) or import the SQL file (more steps).
+
+### Open the database file
+
+1. Open DB Browser for SQLite.
+2. Choose File->Open Database from the menu bar at the top of your screen.
+3. Navigate to where you saved the doaj-article-sample folder and/or files. For example, your Desktop.
+4. Select doaj-article-sample.db.
+
+### Import the SQL file
+
+1. Open DB Browser for SQLite.
+2. Choose File->Import->Database from SQL file from the menu bar at the top of your screen.
+3. Navigate to where you saved the doaj-article-sample folder and/or files. For example, your Desktop.
+4. Select doaj-article-sample.db.sql.
+5. You will be prompted to 'Save As' (i.e. this is the name of the database).
+6. Type 'doaj-article-sample' in the Save as box.
+7. Make sure that 'SQLite database files' is selected in the drop down and that you save the database to a location where you can easily find it, again, like your Desktop.
+8. Click Save.
+9. You should see an 'Executing SQL...' prompt and an 'Import completed.' prompt when finished.
+10. Click OK.
+11. You will see one more prompt which says, "Do you want to save the changes made to the database file...".
+12. Click Save.
+
+## Alternatives: SQLite and SqliteOnline
+
+### SQLite
 
 This step is optional. If you are completing the tutorial with DB Browser for SQLite, you won't need to install SQLite separately. If you would like to run SQLite commands directly on the command line, you may need to install [SQLite](https://www.sqlite.org/) separately.
 
@@ -31,37 +62,20 @@ Copy the file to a directory and open the directory using the windows command li
 
 For a more detailed explanation see this [tutorial](http://www.sqlitetutorial.net/download-install-sqlite/).
 
+### SqliteOnline
 
+This step is optional. If you are completing the tutorial with DB Browser for SQLite, you won't need to use SqliteOnline separately. If you are experiencing trouble with DB Browser for SQLite and/or SQLite or if you would like to run SQL commands online via a browser (nothing to install), then visit [https://sqliteonline.com/](https://sqliteonline.com/).
 
-## Import
+#### Open the database file in SqliteOnline
 
-To import data, you'll need to open DB Browser for SQLite and download a zip file containing the data files for this tutorial.
+1. Choose File->Open DB from the SqliteOnline menu bar.
+2. Navigate to where you saved the doaj-article-sample folder and/or files. For example, your Desktop.
+3. Select doaj-article-sample.db.
 
-1. Download the data files doaj-article-sample.zip from
-    [Figshare](https://doi.org/10.6084/m9.figshare.3409471)
-2. Create a New Database (click on the button at the upper left)
-3. Choose a name for the database (for example, doaj-article-db)
-4. The next screen will present a "Create Table" option. We will create our tables by importing CSV files, so you can close this screen (or click on Cancel)
-5. You should now see Tables(0), Indices(0), Views(0), and Triggers(0) in your Database window.
-6. Start the import under File->Import->Table from CSV file...
-7. Navigate to the directory where your doaj-article-sample folder is located
-8. Select the first file to import (start with articles.csv) and click "open"
-9. Keep the tablename "articles" suggested by DB Browser (for later imports, continue to use articles, journals,
-    licences, languages  publishers),
-10. Make sure that the checkbox for "Column names in first line" is selected (This is important! Otherwise, your column headers will be considered to be the first row of data)
-11. Under  "Fields separator", make sure that ',' (comma) is selected (default)
-12. Use '' as "Quote character" (default)
-13. Leave "Trim fields?" checked (default)
-14. Press __OK__
-15. If successful, you'll receive an "Import Complete" notification.
+#### Open the SQL file in SqliteOnline
 
-## Modify
-
-Your import is complete, but all your columns are currently stored as text fields. You may want to modify this so that some data is stored as numeric or integer rather than text. 
-
-1. From your main database screen, select "articles", then click on "Modify Table" from the menu above
-2. Set the data types for each field: choose TEXT for fields with text:
-   (`Title`, `Authors`, `DOI`, `URL`, `Subjects`, `ISSNs`, `Citation`, `First_Author`),
-   and INTEGER for fields with numbers:
-   (`id`, `LanguageId`, `LicenceId`, `Citation_Count`, `Author_Count`, `Day`, `Month`, `Year`).
-3. Click __OK__
+1. Choose File->Text-SQL->Open SQL from the SqliteOnline menu bar.
+2. Navigate to where you saved the doaj-article-sample folder and/or files. For example, your Desktop.
+3. Select doaj-article-sample.db.sql. 
+4. You should see the SQL in a text box below the home icon.
+5. Click the 'Run' button in the SqliteOnline menu bar.


### PR DESCRIPTION
- Instead of downloading a number of CSV files and importing them one by one, switch to downloading the database file containing the data (and include importing as a SQL file as an alternative)
- Move SQLite instructions to alternative options section
- Add SqliteOnline (instructions) as an alternative

Note: Files are temporarily hosted in the lc-sql repository under files. If this approach is approved, then a new record can be created via Zenodo.

