### PR TITLE
Update 04-aggregating-calculating.md

### DIFF
--- a/_episodes/04-aggregating-calculating.md
+++ b/_episodes/04-aggregating-calculating.md
@@ -46,7 +46,7 @@ ORDER BY AVG(Citation_Count) DESC;
 > > SELECT  ISSNs, COUNT(Title)
 > > FROM articles
 > > GROUP BY ISSNs
-> > ORDER BY Title_Count DESC;
+> > ORDER BY count(Title) DESC;
 > > ~~~
 > > {: .sql}
 > {: .solution}


### PR DESCRIPTION
Regarding line 49: ORDER BY Title_Count DESC;
The field "Title_Count" does not exist, so I think this query can not work this way.

The following query does work:
SELECT ISSNs, count(Title) 
FROM articles
GROUP BY ISSNs 
ORDER BY count(Title) DESC;

Please delete this line and the text below before submitting your contribution.

---

Thanks for contributing! If this contribution is for instructor training, please send an email to checkout@carpentries.org with a link to this contribution so we can record your progress. You’ve completed your contribution step for instructor checkout just by submitting this contribution.  

Please keep in mind that lesson maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum.  If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact The Carpentries Team at team@carpentries.org.  

---
