### PR TITLE
Codeblock styles and minor typos

### DIFF
--- a/episodes/02-selecting-sorting-data.md
+++ b/episodes/02-selecting-sorting-data.md
@@ -41,7 +41,7 @@ In the first query above, we have capitalized the words `SELECT` and `FROM` beca
 
 Example:
 
-```
+```sql
 SELECT Title, Authors, ISSNs, Year
 FROM Articles;
 ```

--- a/episodes/04-ordering-commenting.md
+++ b/episodes/04-ordering-commenting.md
@@ -72,9 +72,9 @@ their effects as we went along.  For complex queries, this is a good strategy, t
 
 When the queries become more complex, it can be useful to add comments to express to yourself, or to others, what you are doing with your query. Comments help explain the logic of a section and provide context for anyone reading the query. It's essentially a way of making notes within your SQL. In SQL, comments begin using <code class="language-plaintext highlighter-rouge">\--</code> and end at the end of the line. To mark a whole paragraph as a comment, you can enclose it with the characters /\* and \*/. For example, a commented version of the above query can be written as:
 
-```
+```sql
 /*In this section, even though JOINS (see link below this code block) are not introduced until Episode 6, we want to give an example how to
-join multiple tables becasue they represent a good example of using comments in SQL to explain more complex queries.*/
+join multiple tables because they represent a good example of using comments in SQL to explain more complex queries.*/
 
 -- First we mention all the fields we want to display
 SELECT articles.Title, articles.First_Author, journals.Journal_Title, publishers.Publisher

--- a/episodes/06-joins-aliases.md
+++ b/episodes/06-joins-aliases.md
@@ -107,7 +107,7 @@ ON publishers.id = journals.PublisherId;
 
 :::::::::::::::::::::::::::::::::::::::  challenge
 
-## Challenge:
+## Challenge
 
 Write a query that returns the `Journal_Title`, `Publisher` name, and number of
 articles published, ordered by number of articles in descending order.

--- a/episodes/08-database-design.md
+++ b/episodes/08-database-design.md
@@ -76,7 +76,7 @@ Conceptually, we know that a journal has only one publisher but a publisher can 
 
 ## More Terminology
 
-The degree of relationship between entities is known as their 'cardinality'. Using the journals-publishers example, the 'publisheres' tble contains a primary key (PK) called 'id'. When the PK is used to create a connection between the original table and a different table, it is called a foreign key (FK) in the other table. To follow the example, we see a field in the 'journal' table called PublisherID that contains the values from the 'id' field in the 'publisher' table, connected the two tables.
+The degree of relationship between entities is known as their 'cardinality'. Using the journals-publishers example, the 'publishers' table contains a primary key (PK) called 'id'. When the PK is used to create a connection between the original table and a different table, it is called a foreign key (FK) in the other table. To follow the example, we see a field in the 'journal' table called PublisherID that contains the values from the 'id' field in the 'publisher' table, connecting the two tables.
 
 There are 4 main types of relationships between tables:
 

--- a/episodes/09-create.md
+++ b/episodes/09-create.md
@@ -175,7 +175,7 @@ stored in any particular order.)
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 
-Adaped from the Software Carpentry Course "Databases and SQL", Chapter 9. 'Creating and Modifying Data'.
+Adapted from the Software Carpentry Course "Databases and SQL", Chapter 9. 'Creating and Modifying Data'.
 <https://swcarpentry.github.io/sql-novice-survey/09-create>
 
 :::::::::::::::::::::::::::::::::::::::: keypoints

--- a/learners/reference.md
+++ b/learners/reference.md
@@ -8,28 +8,28 @@ title: 'SQL Cheat Sheet'
 
 ### Basic query
 
-```
+```sql
 SELECT column_names
 FROM table_name;
 ```
 
 - selects only the specified columns from a table.
 
-```
+```sql
 SELECT * 
 FROM table_name;
 ```
 
 - select all of the columns in a table.
 
-```
-SELECT DINSTINCT column_name 
+```sql
+SELECT DISTINCT column_name 
 FROM table_name;
 ```
 
 - selects only the unique values from a table.
 
-```
+```sql
 SELECT column_names
 FROM table_name
 WHERE column_name operator value;
@@ -39,7 +39,7 @@ WHERE column_name operator value;
 - you can use operators `=`,`<`,`>`, etc
 - you can also combine tests using `AND`, `OR` in the WHERE clause.
 
-```
+```sql
 SELECT column_names
 FROM table_name
 WHERE column_name IN (value1, value2, value3);
@@ -47,7 +47,7 @@ WHERE column_name IN (value1, value2, value3);
 
 - selects only the data where column\_name equals to `value1`, `value2`, and so on.
 
-```
+```sql
 SELECT column_names
 FROM table_name
 ORDER BY column_name ASC;
@@ -59,7 +59,7 @@ ORDER BY column_name ASC;
 
 ### Aggregation
 
-```
+```sql
 SELECT aggregate_function(column_name)
 FROM table_name;
 ```
@@ -68,7 +68,7 @@ FROM table_name;
 - E.g. `SELECT COUNT(*) FROM table_name` will display the total number of records.
 - You can use aggregate functions `COUNT`, `SUM`, `MAX`, `MIN`, `AVG`.
 
-```
+```sql
 SELECT column_name, aggregate_function(column_name)
 FROM table_name
 WHERE column_name operator value
@@ -77,7 +77,7 @@ GROUP BY column_name;
 
 - `GROUP BY` tells SQL what field or fields we want to use to aggregate the data. If we want to group by multiple fields, we give `GROUP BY` a comma separated list.
 
-```
+```sql
 SELECT column_name, aggregate_function(column_name)
 FROM table_name
 GROUP BY column_name
@@ -90,7 +90,7 @@ HAVING aggregate_function(column_name) operator value;
 
 ### Joins and aliases
 
-```
+```sql
 SELECT column_names
 FROM table_name1
 JOIN table_name2 
@@ -100,7 +100,7 @@ ON table_name1.column_name = table_name2.column_name;
 - Combine data from two tables where the values of column\_name in the two tables are the same.
 - Instead of `ON`, you can use the `USING` keyword as a shorthand. E.g. `USING (coolumn_name)`.
 
-```
+```sql
 SELECT alias1.column_name1, alias1.column_name2, alias2.column_name3
 FROM table_name1 AS alias1
 JOIN table_name2 AS alias2
@@ -114,7 +114,7 @@ ON alias1.column_name = alias2.column_name;
 
 ### Saving queries
 
-```
+```sql
 CREATE VIEW viewname AS
 SELECT column_names
 FROM table_name;
@@ -126,7 +126,7 @@ FROM table_name;
 
 ### Commenting
 
-```
+```sql
 -- Select all columns
 SELECT * 
 -- From the table_name


### PR DESCRIPTION
Closes #156 

Fixes some code blocks that were not marked as SQL, meaning they do not display the same way in the lesson. Also fixed some typos in the lesson.