### PR TITLE
replace URL in broken link

### DIFF
--- a/episodes/06-joins-aliases.md
+++ b/episodes/06-joins-aliases.md
@@ -49,7 +49,7 @@ USING (ISSNs);
 
 This figure shows the relations between the tables and helps to visualise joining or linking the tables in the database:
 ![](fig/articles-erd-v02.png){alt='Articles Database'}
-We will cover [relational database design](08-database-design.md) in the next episode. In addition to visual above, *[SQL Join Types Explained Visually](https://dataschool.com/how-to-teach-people-sql/sql-join-types-explained-visually/)* provides visual/animated examples to help convey to learners what is happening in SQL `JOIN`s.
+We will cover [relational database design](08-database-design.md) in the next episode. In addition to visual above, *[SQL Join Types Explained Visually](https://www.atlassian.com/data/sql/sql-join-types-explained-visually)* provides visual/animated examples to help convey to learners what is happening in SQL `JOIN`s.
 
 When joining tables, you can specify the columns you want by using `table.colname` instead of selecting all the columns using `*`. For example:
 


### PR DESCRIPTION
Reported by a community member. I think this is the new location of the same resource we were linking to previously.